### PR TITLE
Improve UI with floating call button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HashRouter as Router, Routes, Route } from "react-router-dom";
 import ScrollToTop from './components/ScrollToTop';
+import FloatingOrderButton from './components/FloatingOrderButton';
 import Index from "./pages/Index";
 import Story from "./pages/Story";
 import Benefits from "./pages/Benefits";
@@ -21,7 +22,8 @@ function App() {
         <Sonner />
         <Router>
           <ScrollToTop />
-          <div className="pt-16"> 
+          <FloatingOrderButton />
+          <div className="pt-16">
             <Routes>
               <Route path="/" element={<Index />} />
               <Route path="/story" element={<Story />} />

--- a/src/components/FlavourCarousel.tsx
+++ b/src/components/FlavourCarousel.tsx
@@ -50,7 +50,7 @@ const FlavourCarousel = () => {
   }, [flavours.length]);
 
   return (
-    <section className="py-20 bg-ivory">
+    <section id="flavors" className="py-20 bg-ivory">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <h2 className="text-4xl font-playfair font-bold text-center text-cocoa mb-16">
           Discover Our <span className="gradient-text">Signature Flavours</span>

--- a/src/components/FloatingOrderButton.tsx
+++ b/src/components/FloatingOrderButton.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { Phone } from 'lucide-react';
+
+const FloatingOrderButton = () => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setVisible(window.scrollY > 200);
+    };
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <a
+      href="tel:+919322973362"
+      className={`fixed bottom-24 right-6 z-40 transition-opacity duration-300 ${
+        visible ? 'opacity-100' : 'opacity-0 pointer-events-none'
+      }`}
+      aria-label="Call to Order"
+    >
+      <div className="bg-honey text-white px-4 py-3 rounded-full shadow-lg flex items-center gap-2 hover:bg-honey/90">
+        <Phone className="w-5 h-5" />
+        <span className="font-medium">Order Now</span>
+      </div>
+    </a>
+  );
+};
+
+export default FloatingOrderButton;


### PR DESCRIPTION
## Summary
- add a floating "Order Now" button
- hook floating button into the app layout
- anchor hero carousel scroll target

## Testing
- `npm run lint` *(fails: ConfigError about globals)*

------
https://chatgpt.com/codex/tasks/task_e_683fb47863b0832eafad6da73f9d5708